### PR TITLE
Add 2 variables allowing to setup python-pip package and pip command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ dehydrated_dependencies:
   - git
   - openssl
   - curl
+dehydrated_pip_package: python-pip
 dehydrated_install_root: /opt/dehydrated
 dehydrated_update: yes
 dehydrated_version: HEAD

--- a/tasks/dns-01-lexicon.yml
+++ b/tasks/dns-01-lexicon.yml
@@ -1,10 +1,11 @@
 ---
 - name: Ensure python-pip is installed
-  apt: name=python-pip
+  apt: name="{{ dehydrated_pip_package }}"
 
 - name: Install dns-lexicon
   pip:
     name: dns-lexicon
+    executable: "{{ dehydrated_pip_executable|default(omit) }}"
 
 - name: Copy hook script
   copy:


### PR DESCRIPTION
Hello, 
On Ubuntu 18.04 python3 is installed instead of 2.7, if we use your role Python 2.7 is installed side by side with Python, which is unnecessary

To install pip we need to install python3-pip (instead python-pip), this PR allow to define the pip package name.

Then when pip is installed, the pip command with Python 3 must be pip3 instead of pip.
The PR allow to define an optional variable named dehydrated_pip_executable to do so.

Thanks
Yoann
