### PR TITLE
Add varaible to configure url of dehydrated repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ dehydrated_dependencies:
   - git
   - openssl
   - curl
+dehydrated_repo_url: https://github.com/lukas2511/dehydrated.git
 dehydrated_install_root: /opt/dehydrated
 dehydrated_update: yes
 dehydrated_version: HEAD

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Checkout dehydrated from github
   git:
-    repo: "https://github.com/lukas2511/dehydrated.git"
+    repo: "{{ dehydrated_repo_url }}"
     update: "{{ dehydrated_update }}"
     dest: "{{ dehydrated_install_root }}"
     version: "{{ dehydrated_version }}"


### PR DESCRIPTION
Currently, dehydrated have a blocking bug in staging environment due to à change in LetsEncrypt API (https://github.com/lukas2511/dehydrated/issues/647)

A PR have been sent but not merged (https://github.com/lukas2511/dehydrated/pull/648)

Your role doesn't permit to use a fork of dehydrated (with issue fixed), my PR allow it.