### PR TITLE
Use a list for dehydrated_domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ TIMESTAMP | Timestamp when the  certificate was created.
     dehydrated_accept_letsencrypt_terms: yes
     dehydrated_contactemail: hostmaster@example.com
     dehydrated_wellknown: /var/www/example.com/.well-known/acme-challenge
-    dehydrated_domains: |
-      example.com
+    dehydrated_domains:
+      - example.com
     dehydrated_deploycert: |
       service nginx reload
   roles:
@@ -166,8 +166,8 @@ TIMESTAMP | Timestamp when the  certificate was created.
     dehydrated_lexicon_dns:
       LEXICON_CLOUDFLARE_USERNAME: hostmaster@example.com
       LEXICON_CLOUDFLARE_TOKEN: f7e7e...
-    dehydrated_domains: |
-      example.com
+    dehydrated_domains:
+      - example.com
     dehydrated_deploycert: |
       service nginx reload
   roles:
@@ -179,10 +179,10 @@ TIMESTAMP | Timestamp when the  certificate was created.
 - hosts: servers
   vars:
     # [...]
-    dehydrated_domains: |
-      example.com www.example.com
-      sub.example.com
-      service.example.com
+    dehydrated_domains:
+      - example.com www.example.com
+      - sub.example.com
+      - service.example.com
     dehydrated_deploycert:
       example.com: |
         service nginx reload

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -51,8 +51,8 @@ provisioner:
       http01:
         dehydrated_contactemail: notused@le2.wtf
         dehydrated_accept_letsencrypt_terms: true
-        dehydrated_domains: |
-          le2.wtf
+        dehydrated_domains:
+          - le2.wtf
         dehydrated_wellknown: /tmp/www/.well-known/acme-challenge
         dehydrated_use_lexicon: false
         dehydrated_ca: http://10.77.77.1:4001/directory
@@ -60,8 +60,8 @@ provisioner:
       dns01:
         dehydrated_contactemail: notused@le3.wtf
         dehydrated_accept_letsencrypt_terms: true
-        dehydrated_domains: |
-          le3.wtf
+        dehydrated_domains:
+          - le3.wtf
         dehydrated_challengetype: dns-01
         dehydrated_ca: http://10.77.77.1:4001/directory
         dehydrated_cronjob: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,12 +30,15 @@
     mode: 0600
 
 - name: Generate dehydrated domains.txt
-  copy:
+  lineinfile:
     dest: /etc/dehydrated/domains.txt
-    content: "{{ dehydrated_domains }}"
+    line: "{{ item }}"
+    regexp: '^{{ item }}'
+    create: true
     owner: root
     group: root
     mode: 0600
+  loop: "{{ dehydrated_domains }}"
   notify: run dehydrated
 
 - import_tasks: hooks.yml


### PR DESCRIPTION
The README says it is a list while it is a string. Not sure why though.