### PR TITLE
update and fix testing to make Travis happy again

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ When `dehydrated_challengetype` is set to `dns-01`, this role will automatically
 
 ### Platforms supporting `dns-01` challenges
 
-All platforms supported by this role will work with `dns-01` challenges, **except** for Debian 8 (codename: Jessie).  The `dns-lexicon` package requires Python version >= 3.5, which is not available by default on Debian 8.
+All platforms supported by this role will work with `dns-01` challenges wherever the latest version of `lexicon` can be installed.  `lexicon` is pretty aggressive about deprecating older versions of Python, and it (indirectly) relies upon the `cryptography` package which is similarly aggressive.  For those who need this on older distributions, it may be possible to find specific older versions of `lexicon` and `cryptography` to install that will work on the following distributions:
+
+  - Debian 8 (Jessie)
+  - Ubuntu 16.04 (Xenial)
 
 ## using systemd timers
 
@@ -246,7 +249,7 @@ If you decide, that you don't need the hook anymore, you can add `state: absent`
 
 # Testing
 
-This role is automatically tested using Travis CI. Local testing can be done using Vagrant. Both run `molecule/setup.sh` script to setup the testing environment.
+This role is automatically tested using Travis CI. Local testing can be done using Vagrant.  Both local (Vagrant) and Travis utilize the `molecule/setup.sh` script to setup the testing environment.
 
 Multiple services are started in the environment to test both http-01 and dns-01.
 
@@ -256,9 +259,9 @@ boulder (using docker) | Let's Encrypt CA for validations
 nginx | webserver for http-01
 powerdns | Used as a nameserver for dns-01. lexicon as a plugin to manipulate records.
 
-## Vagrant testing example
+## Local Vagrant testing example
 
-Assuming you have Vagrant already configured, run a complete test via Vagrant:
+Assuming you have Vagrant already configured, run a complete test via:
 
     vagrant up
     vagrant ssh

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: Alexander Zielke
+  role_name: dehydrated
   description: Install, confgure and run dehydrated to get Let's Encrypt SSL certificates
 
   license: MIT

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,9 +32,9 @@ platforms:
   - name: ubuntu1804-dns01
     image: ubuntu:18.04
     groups: [dns01]
-  - name: ubuntu1604-dns01
-    image: ubuntu:16.04
-    groups: [dns01]
+  # - name: ubuntu1604-dns01
+  #   image: ubuntu:16.04
+  #   groups: [dns01]
   # - name: debian8-dns01
   #   image: debian:8
   #   groups: [dns01]

--- a/molecule/setup.sh
+++ b/molecule/setup.sh
@@ -13,7 +13,7 @@ if [ -d /vagrant ]; then
 fi
 
 # Install molecule
-pip install "molecule>=3.0.3" testinfra docker
+pip install "molecule[ansible,docker,lint]" testinfra docker
 
 # Install linting tools
 pip install yamllint ansible-lint flake8

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -4,6 +4,7 @@
   template:
     src: "{{ item }}.j2"
     dest: /etc/systemd/system/{{ item }}
+    mode: 0644
   loop:
     - dehydrated.service
     - dehydrated.timer


### PR DESCRIPTION
A few minor tweaks to make Travis happy again

 - testing config needs some minor love to comply with the ever-changing requirements of Molecule.
 - make lint happy by adding mode to installed systemd files
 - disable dns-01 on Ubuntu 16.04 since we can't get latest lexicon on that platform for lack of newer Python.

Also updated the README accordingly.

resolves #24 