### PR TITLE
Add support for per certificate PRIVATE_KEY_RENEW configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dehydrated_cert_config:
    wellknown: # override WELLKNOWN (optional)
    key_algo: # override KEY_ALGO (optional)
    keysize: # override KEYSIZE (optional)
+   private_key_renew: # override PRIVATE_KEY_RENEW (optional)
 ```
 
 ## dehydrated_deploycert

--- a/templates/certconfig.j2
+++ b/templates/certconfig.j2
@@ -2,4 +2,5 @@
 {% if item.challengetype is defined %}CHALLENGETYPE={{ item.challengetype }}{% endif %}
 {% if item.key_algo is defined %}KEY_ALGO={{ item.key_algo }}{% endif %}
 {% if item.keysize is defined %}KEYSIZE={{ item.keysize }}{% endif %}
+{% if item.private_key_renew is defined %}PRIVATE_KEY_RENEW={{ item.private_key_renew }}{% endif %}
 {% if item.wellknown is defined %}WELLKNOWN={{ item.wellknown }}{% endif %}


### PR DESCRIPTION
As it is supported by [dehydrated](https://github.com/dehydrated-io/dehydrated/blob/5c1551e946456f534cf46b6ebabe4353bf0b0530/docs/per-certificate-config.md).
