### PR TITLE
Fix missing systemd service network requirement

### DIFF
--- a/templates/dehydrated.service.j2
+++ b/templates/dehydrated.service.j2
@@ -1,5 +1,7 @@
 [Unit]
 Description=ACME Cert renewal
+After=network-online.target
+Requires=network-online.target
 ConditionFileNotEmpty=/etc/dehydrated/domains.txt
 {% if dehydrated_systemd_timer_onfailure is defined %}
 OnFailure={{ dehydrated_systemd_timer_onfailure }}


### PR DESCRIPTION
This leads to dehydrated trying to run at boot time before network is
available.