### PR TITLE
feat: allow failure of cron task if not using cron

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     job: "{{ dehydrated_install_root }}/dehydrated -c"
     cron_file: dehydrated
     state: "{{ 'present' if dehydrated_cronjob else 'absent' }}"
+  ignore_errors: "{{ false if dehydrated_cronjob else true }}"
 
 - import_tasks: systemd.yml
 


### PR DESCRIPTION
The `cron` module requires a Cron system to be installed, which modern systems may not (for example, Debian 12 does not by default). When not using cron, allow the failure of the `cron` task (which would remove the crontab entry).