### PR TITLE
Support for the OS provided lexicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ dehydrated_update | Update dehydrated sources on ansible run | yes
 dehydrated_version | Which version to check out from github | HEAD
 dehydrated_challengetype | Challenge to use (http-01, dns-01) | http-01
 dehydrated_use_lexicon | Enable the use of lexicon | yes if dehydrated_challengetype == dns-01 else no
+dehydrated_use_os_lexicon | Use OS provided lexicon instead of pip provided one | no
+dehydrated_os_lexicon_package | Name of lexicon package | python3-lexicon if ansible is running on python3, otherwise python-lexicon
 dehydrated_lexicon_dns | Options for running lexicon | {}
 dehydrated_hooks | Dict with hook-names for which to add scripts |
 dehydrated_hook_scripts | Add additional scripts to hooks-Directory | []
@@ -54,7 +56,7 @@ dehydrated_run_on_changes | If dehydrated should run if the list of domains chan
 dehydrated_systemd_timer_onfailure | If set, an OnFailure-Directive will be added to the systemd unit |
 dehydrated_cert_config | Override configuration for certificates | []
 dehydrated_repo_url | Specify URL to git repository of dehydrated | https://github.com/dehydrated-io/dehydrated.git
-dehydrated_install_pip | Whether pip will be installed when using lexicon | yes
+dehydrated_install_pip | Whether pip will be installed when using lexicon | yes if dehydrated_use_os_lexicon is false, no otherwise
 dehydrated_pip_package | Name of pip package | python3-pip if ansible is running on python3, otherwise python-pip
 dehydrated_pip_executable | Name of pip executable to use | autodetected by pip module
 
@@ -68,7 +70,7 @@ Alternatively, if you've already setup `dehydrated` once and want to use the sam
 
 ## Using dns-01 challenges
 
-When `dehydrated_challengetype` is set to `dns-01`, this role will automatically install `lexicon` from python pip to be able to set and remove the necessary DNS records needed to obtain an SSL certificate.
+When `dehydrated_challengetype` is set to `dns-01`, this role will automatically install `lexicon` from python pip or OS repositories to be able to set and remove the necessary DNS records needed to obtain an SSL certificate.
 
 `lexicon` uses environment variables for username/token and password/secret; see examples below.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,10 +14,12 @@ dehydrated_keysize: 4096
 dehydrated_ca: "https://acme-v02.api.letsencrypt.org/directory"
 dehydrated_cronjob: yes
 dehydrated_use_lexicon: "{{ dehydrated_challengetype == 'dns-01' }}"
+dehydrated_use_os_lexicon: false
+dehydrated_os_lexicon_package: "{{ 'python3-lexicon' if ansible_python_version is version('3', '>=') else 'python-lexicon' }}"
 dehydrated_run_on_changes: yes
 dehydrated_systemd_timer: no
 dehydrated_hook_scripts: []
 dehydrated_cert_config: []
 # dehydrated_systemd_timer_onfailure: some_unit.service
-dehydrated_install_pip: yes
+dehydrated_install_pip: "{{ not (dehydrated_use_os_lexicon | bool) }}"
 dehydrated_pip_package: "{{ 'python3-pip' if ansible_python_version is version('3', '>=') else 'python-pip' }}"

--- a/tasks/dns-01-lexicon.yml
+++ b/tasks/dns-01-lexicon.yml
@@ -4,10 +4,16 @@
     name: "{{ dehydrated_pip_package }}"
   when: dehydrated_install_pip
 
-- name: Install dns-lexicon
+- name: Install dns-lexicon (pip)
   pip:
     name: dns-lexicon
     executable: "{{ dehydrated_pip_executable|default(omit) }}"
+  when: not dehydrated_use_os_lexicon
+
+- name: Install dns-lexicon (os)
+  package:
+    name: "{{ dehydrated_os_lexicon_package }}"
+  when: dehydrated_use_os_lexicon
 
 - name: Copy hook script
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     job: "{{ dehydrated_install_root }}/dehydrated -c"
     cron_file: dehydrated
     state: "{{ 'present' if dehydrated_cronjob else 'absent' }}"
+  ignore_errors: "{{ false if dehydrated_cronjob else true }}"
 
 - import_tasks: systemd.yml
 


### PR DESCRIPTION
In modern systems, the python lexicon package is often provided by the official OS repositories.
This PR adds support for installing lexicon python package officially supported by the OS.

This is somewhat related to https://github.com/clutterbox/ansible-dehydrated/pull/21.